### PR TITLE
Generic attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 rete_elixir-*.tar
 
+# Ignore elixir language server cache
+.elixir_ls/
+

--- a/lib/nodes/type_node.ex
+++ b/lib/nodes/type_node.ex
@@ -13,6 +13,19 @@ defmodule Retex.Node.Type do
 
   defimpl Retex.Protocol.Activation do
     def activate(
+          %Retex.Node.Type{class: _class} = neighbor,
+          %Retex{graph: _graph} = rete,
+          %Retex.Wme{identifier: "$" <> identifier = var} = wme,
+          bindings,
+          tokens
+        ) do
+      rete
+      |> Retex.create_activation(neighbor, wme)
+      |> Retex.add_token(neighbor, wme, Map.merge(bindings, %{var => identifier}), tokens)
+      |> Retex.continue_traversal(Map.merge(bindings, %{var => identifier}), neighbor, wme)
+    end
+
+    def activate(
           %Retex.Node.Type{class: "$" <> _variable = var} = neighbor,
           %Retex{graph: _graph} = rete,
           %Retex.Wme{identifier: identifier} = wme,

--- a/lib/nodes/type_node.ex
+++ b/lib/nodes/type_node.ex
@@ -13,16 +13,18 @@ defmodule Retex.Node.Type do
 
   defimpl Retex.Protocol.Activation do
     def activate(
-          %Retex.Node.Type{class: _class} = neighbor,
+          %Retex.Node.Type{class: class} = neighbor,
           %Retex{graph: _graph} = rete,
-          %Retex.Wme{identifier: "$" <> identifier = var} = wme,
+          %Retex.Wme{identifier: "$" <> _identifier = var} = wme,
           bindings,
           tokens
         ) do
+      new_bindings = Map.merge(bindings, %{var => class})
+
       rete
       |> Retex.create_activation(neighbor, wme)
-      |> Retex.add_token(neighbor, wme, Map.merge(bindings, %{var => identifier}), tokens)
-      |> Retex.continue_traversal(Map.merge(bindings, %{var => identifier}), neighbor, wme)
+      |> Retex.add_token(neighbor, wme, new_bindings, tokens)
+      |> Retex.continue_traversal(new_bindings, neighbor, wme)
     end
 
     def activate(

--- a/lib/retex.ex
+++ b/lib/retex.ex
@@ -359,12 +359,8 @@ defmodule Retex do
             acc = Map.put_new(acc, variable, type)
             {acc, [condition | conds]}
 
-          %Fact.HasAttribute{owner: "$" <> _variable_name = var} = condition ->
-            if type = Map.get(acc, var) do
-              {acc, [%{condition | owner: type} | conds]}
-            else
-              {acc, [condition | conds]}
-            end
+          %Fact.HasAttribute{owner: _var} = condition ->
+            {acc, [condition | conds]}
 
           %Fact.Relation{} = condition ->
             %{from: from, name: _rel_name, to: to, via: via} = condition

--- a/test/retex_test.exs
+++ b/test/retex_test.exs
@@ -1,6 +1,6 @@
 defmodule RetexTest do
   use ExUnit.Case
-  alias Retex.{Wme, Facts}
+  alias Retex.{Facts}
   import Facts
   doctest Retex
 
@@ -65,8 +65,8 @@ defmodule RetexTest do
       |> Retex.add_production(rule)
       |> Retex.add_production(rule_b)
 
-    assert 22 == Graph.edges(network.graph) |> Enum.count()
-    assert 18 == Graph.vertices(network.graph) |> Enum.count()
+    assert 20 == Graph.edges(network.graph) |> Enum.count()
+    assert 17 == Graph.vertices(network.graph) |> Enum.count()
   end
 
   test "add a production" do
@@ -120,9 +120,8 @@ defmodule RetexTest do
 
     test "apply inference and replace variables in a WME" do
       given = [
-        isa("$thing", :Account),
-        has_attribute("$thing", :status, :==, "$a"),
-        has_attribute("$thing", :premium, :==, true)
+        has_attribute(:Account, :status, :==, "$a"),
+        has_attribute(:Account, :premium, :==, true)
       ]
 
       action = [
@@ -132,9 +131,8 @@ defmodule RetexTest do
       rule = create_rule(lhs: given, rhs: action)
 
       given_2 = [
-        isa("$thing_a", :AccountB),
-        has_attribute("$thing_a", :status, :==, "$a_a"),
-        has_attribute("$thing_a", :premium, :==, true)
+        has_attribute(:AccountB, :status, :==, "$a_a"),
+        has_attribute(:AccountB, :premium, :==, true)
       ]
 
       action_2 = [
@@ -227,9 +225,8 @@ defmodule RetexTest do
 
     test "apply inference with rules in which we use isa statements" do
       given = [
-        isa("$thing", :Account),
-        has_attribute("$thing", :status, :==, "$a"),
-        has_attribute("$thing", :premium, :==, true)
+        has_attribute(:Account, :status, :==, "$a"),
+        has_attribute(:Account, :premium, :==, true)
       ]
 
       action = [
@@ -239,9 +236,8 @@ defmodule RetexTest do
       rule = create_rule(lhs: given, rhs: action)
 
       given_2 = [
-        isa("$thing_a", :AccountB),
-        has_attribute("$thing_a", :status, :==, "$a_a"),
-        has_attribute("$thing_a", :premium, :==, true)
+        has_attribute(:AccountB, :status, :==, "$a_a"),
+        has_attribute(:AccountB, :premium, :==, true)
       ]
 
       action_2 = [
@@ -273,9 +269,8 @@ defmodule RetexTest do
       wme_3 = Retex.Wme.new(:Family, :size, 10)
 
       given = [
-        isa("$thing", :Account),
-        has_attribute("$thing", :status, :==, "$a"),
-        has_attribute("$thing", :premium, :==, true)
+        has_attribute(:Account, :status, :==, "$a"),
+        has_attribute(:Account, :premium, :==, true)
       ]
 
       action = [
@@ -302,9 +297,8 @@ defmodule RetexTest do
       wme_3 = Retex.Wme.new(:Family, :size, 10)
 
       given = [
-        isa("$thing", :Account),
-        has_attribute("$thing", :status, :==, "$a"),
-        has_attribute("$thing", :premium, :==, true)
+        has_attribute(:Account, :status, :==, "$a"),
+        has_attribute(:Account, :premium, :==, true)
       ]
 
       action = [
@@ -333,9 +327,8 @@ defmodule RetexTest do
       wme_3 = Retex.Wme.new(:Family, :size, 10)
 
       given = [
-        isa("$thing", :Account),
-        has_attribute("$thing", :status, :==, "$a"),
-        has_attribute("$thing", :premium, :==, false),
+        has_attribute(:Account, :status, :==, "$a"),
+        has_attribute(:Account, :premium, :==, false),
         has_attribute(:Family, :size, :==, "$c")
       ]
 
@@ -354,39 +347,6 @@ defmodule RetexTest do
 
       agenda = network.agenda |> Enum.map(&Map.get(&1, :action))
       assert agenda == [[{"$thing", :account_status, :silver}]]
-    end
-
-    test "apply inference with the use of relations" do
-      wmes = [
-        Wme.new(:Account, :status, :silver),
-        Wme.new(:Account, :id, 1),
-        Wme.new(:Family, :size, 10),
-        Wme.new(:Family, :account_id, 1)
-      ]
-
-      given = [
-        has_attribute(:Account, :status, :==, "$status"),
-        has_attribute(:Family, :size, :==, "$family_size"),
-        relation(:Account, :from_family, :Family)
-      ]
-
-      action = [
-        {:Account, :id, "$account_id"},
-        {:Account, :duplicated_status, "$status"}
-      ]
-
-      rule = create_rule(lhs: given, rhs: action)
-
-      network = Retex.add_production(Retex.new(), rule)
-
-      network =
-        Enum.reduce(wmes, network, fn wme, network ->
-          Retex.add_wme(network, wme)
-        end)
-
-      agenda = network.agenda |> Enum.map(&Map.get(&1, :action))
-
-      assert agenda == [[{:Account, :id, 1}, {:Account, :duplicated_status, :silver}]]
     end
 
     test "apply inference with the use of variables and they DONT match" do
@@ -513,12 +473,12 @@ defmodule RetexTest do
         network
         |> Retex.add_wme(wme_4)
 
-      agenda = network.agenda |> Enum.map(&Map.get(&1, :action))
+      agenda = network.agenda |> Enum.map(&Map.get(&1, :action)) |> Enum.sort()
 
       assert agenda == [
-               [{:Flight, :account_status_a, 10}],
+               [{:Flight, :account_status, 10}],
                [{:Flight, :account_status, :silver}],
-               [{:Flight, :account_status, 10}]
+               [{:Flight, :account_status_a, 10}]
              ]
     end
 


### PR DESCRIPTION
When inserting a working memory element allow the use of variables as type, this will match any type of the network as discriminate only by the attribute name