### PR TITLE
Remove unnecessary mix install

### DIFF
--- a/benchmark/rule_chain.exs
+++ b/benchmark/rule_chain.exs
@@ -1,9 +1,3 @@
-Mix.install([
-  {:retex, path: "./"},
-  {:duration, "~> 0.1.0"},
-  {:timex, "~> 3.7.6"}
-])
-
 defmodule Benchmark do
   alias Retex.Agenda
 


### PR DESCRIPTION
From inside the project, the rule chain benchmark can be run as:

```elixir
$ mix run benchmark/rule_chain.exs

14:29:54.065 [info] Adding 20000 rules...

14:29:54.840 [info] %{num_edges: 139999, num_vertices: 119998, size_in_bytes: 81291312, type: :directed}

14:29:54.865 [info] Adding 20000 rules took 669.612 milliseconds

14:29:54.880 [info] Adding the working memory took 10.666 milliseconds
```

I think that it can be safely removed :)