### PR TITLE
Avoid replacing the same node with the same bindings twice

### DIFF
--- a/lib/nodes/p_node.ex
+++ b/lib/nodes/p_node.ex
@@ -31,12 +31,10 @@ defmodule Retex.Node.PNode do
       tokens = Map.get(tokens, parent.id)
 
       if Enum.all?(parents, &Map.get(activations, &1.id)) do
-        productions =
-          tokens
-          |> Enum.map(fn token -> Retex.replace_bindings(neighbor, token.bindings) end)
-          |> List.flatten()
-          |> Enum.uniq()
-          |> apply_filters(filters)
+        bindings =
+          tokens |> Enum.uniq() |> Enum.reduce(%{}, fn t, acc -> Map.merge(acc, t.bindings) end)
+
+        productions = apply_filters([Retex.replace_bindings(neighbor, bindings)], filters)
 
         new_rete = %{
           rete

--- a/lib/nodes/p_node.ex
+++ b/lib/nodes/p_node.ex
@@ -31,9 +31,7 @@ defmodule Retex.Node.PNode do
       tokens = Map.get(tokens, parent.id)
 
       if Enum.all?(parents, &Map.get(activations, &1.id)) do
-        bindings =
-          tokens |> Enum.uniq() |> Enum.reduce(%{}, fn t, acc -> Map.merge(acc, t.bindings) end)
-
+        bindings = tokens |> Enum.reduce(%{}, fn t, acc -> Map.merge(acc, t.bindings) end)
         productions = apply_filters([Retex.replace_bindings(neighbor, bindings)], filters)
 
         new_rete = %{

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -11,11 +11,11 @@ defmodule Retex.Token do
   tokens that instantiate the LHS. The terminal node sends out of the black box
   the information that the conflict set must be changed. - RETE Match Algorithm - Forgy OCR
   """
-  defstruct wmem: nil, node: nil, bindings: %{}, id: nil
+  defstruct wmem: nil, node: nil, bindings: %{}
 
   @type t() :: %Retex.Token{}
 
   def new do
-    Map.put(%__MODULE__{}, :id, Retex.hash(:uuid4))
+    %__MODULE__{}
   end
 end

--- a/test/retex_test.exs
+++ b/test/retex_test.exs
@@ -739,7 +739,6 @@ defmodule RetexTest do
       agenda = network.agenda |> Enum.map(&Map.get(&1, :action)) |> Enum.sort()
 
       assert agenda == [
-               [{:Flight, :account_status, 10}],
                [{:Flight, :account_status, :silver}],
                [{:Flight, :account_status_a, 10}]
              ]


### PR DESCRIPTION
By using :cprof from Erlang and thanks to @kpanic (https://github.com/lorenzosinisi/neural_bridge/pull/7/files) we understood that we would be replacing the same bindings many time even tho the bindings might be the same. This PR optimizes the way we do binding replacements for the PNodes making the library a lot more efficient